### PR TITLE
Replace eslint config with our own

### DIFF
--- a/packages/react-scripts/CHANGES.md
+++ b/packages/react-scripts/CHANGES.md
@@ -1,0 +1,11 @@
+### 5.0.2 (April 12, 2022)
+
+- Replace eslint config with `@dagster-io/eslint-config` to avoid mismatch errors with `eslint-plugin-react` in our apps.
+
+### 5.0.1 (January 17, 2022)
+
+- Fix some dependencies and metadata.
+
+### 5.0.0 (January 14, 2022)
+
+- Initial commit.

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -789,7 +789,7 @@ module.exports = function (webpackEnv) {
           cwd: paths.appPath,
           resolvePluginsRelativeTo: __dirname,
           baseConfig: {
-            extends: [require.resolve('eslint-config-react-app/base')],
+            extends: [require.resolve('@dagster-io/eslint-config')],
             rules: {
               ...(!hasJsxRuntime && {
                 'react/react-in-jsx-scope': 'error',

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -29,6 +29,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "^7.16.0",
+    "@dagster-io/eslint-config": "^1.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@svgr/webpack": "^5.5.0",
     "babel-jest": "^27.4.2",
@@ -45,7 +46,6 @@
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "eslint": "^8.3.0",
-    "eslint-config-react-app": "^7.0.0",
     "eslint-webpack-plugin": "^3.1.1",
     "file-loader": "^6.2.0",
     "fs-extra": "^10.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/react-scripts",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Dagster customization of configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use `@dagster-io/eslint-config` in our react-scripts fork.

This will allow us to avoid issues of `eslint-plugin-react` mismatches for CRA consumers of `@dagster-io/eslint-config`.

### Test plan

In `dagit/packages/app`, point `react-scripts` at my local repo, run `yarn`. Run the dagit app, then introduce a lint error in `src/app/index.tsx`. Verify that the app runs without any plugin mismatch errors, and that the lint error surfaces in the browser.