### PR TITLE
Insert nonce placeholder in webpack config

### DIFF
--- a/packages/react-scripts/CHANGES.md
+++ b/packages/react-scripts/CHANGES.md
@@ -1,3 +1,7 @@
+### 5.0.4 (July 12, 2022)
+
+- Insert nonce placeholder on generated head tags
+
 ### 5.0.3 (May 3, 2022)
 
 - Merge upstream changes, including v5.0.1

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -102,8 +102,10 @@ class NoncePlaceholder {
         (data, cb) => {
           const { headTags } = data;
           if (dagsterConfig.noncePlaceholder) {
-            headTags.forEach(x => {
-              x.attributes.nonce = dagsterConfig.noncePlaceholder;
+            headTags.forEach(tag => {
+              if (tag.tagName === 'script') {
+                tag.attributes.nonce = dagsterConfig.noncePlaceholder;
+              }
             });
           }
           cb(null, data);

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -24,7 +24,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const ESLintPlugin = require('eslint-webpack-plugin');
-const {RawSource} = require('webpack-sources');
+const { RawSource } = require('webpack-sources');
 const paths = require('./paths');
 const modules = require('./modules');
 const getClientEnvironment = require('./env');
@@ -88,7 +88,29 @@ let dagsterConfig;
 try {
   dagsterConfig = require(paths.dagsterConfig);
 } catch (e) {
-  console.log('⚠️  WARNING: No .dagster.js file found. Continuing without Dagster-specific config.');
+  console.log(
+    '⚠️  WARNING: No .dagster.js file found. Continuing without Dagster-specific config.'
+  );
+}
+
+// https://towardsdatascience.com/content-security-policy-how-to-create-an-iron-clad-nonce-based-csp3-policy-with-webpack-and-nginx-ce5a4605db90
+class NoncePlaceholder {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('NoncePlaceholder', compilation => {
+      HtmlWebpackPlugin.getHooks(compilation).afterTemplateExecution.tapAsync(
+        'NoncePlaceholder',
+        (data, cb) => {
+          const { headTags } = data;
+          if (dagsterConfig.noncePlaceholder) {
+            headTags.forEach(x => {
+              x.attributes.nonce = dagsterConfig.noncePlaceholder;
+            });
+          }
+          cb(null, data);
+        }
+      );
+    });
+  }
 }
 // @dagster-io END
 
@@ -100,9 +122,18 @@ module.exports = function (webpackEnv) {
 
   // @dagster-io START
   const cspConfig = dagsterConfig ? dagsterConfig.csp(webpackEnv) : null;
-  const {policy: cspPolicy, options: cspOptions, outputFilename} = cspConfig || {};
+  const {
+    policy: cspPolicy,
+    options: cspOptions,
+    outputFilename,
+  } = cspConfig || {};
   if (outputFilename && isEnvProduction) {
-    cspOptions.processFn = (builtPolicy, _htmlPluginData, _obj, compilation) => {
+    cspOptions.processFn = (
+      builtPolicy,
+      _htmlPluginData,
+      _obj,
+      compilation
+    ) => {
       compilation.emitAsset(outputFilename, new RawSource(builtPolicy));
     };
   }
@@ -337,7 +368,7 @@ module.exports = function (webpackEnv) {
         }),
         ...(modules.webpackAliases || {}),
         // @dagster-io START
-        ...(dagsterConfig ? (dagsterConfig.moduleAliases || {}) : {}),
+        ...(dagsterConfig ? dagsterConfig.moduleAliases || {} : {}),
         // @dagster-io END
       },
       plugins: [
@@ -433,7 +464,10 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               // @dagster-io START
-              include: [paths.appSrc, ...(dagsterConfig ? (dagsterConfig.srcPaths || []) : [])],
+              include: [
+                paths.appSrc,
+                ...(dagsterConfig ? dagsterConfig.srcPaths || [] : []),
+              ],
               // @dagster-io END
               loader: require.resolve('babel-loader'),
               options: {
@@ -652,7 +686,12 @@ module.exports = function (webpackEnv) {
 
       // @dagster-io START
       // Set CSP configuration from .dagster.js
-      cspPolicy && new CspHtmlWebpackPlugin(cspPolicy, cspOptions),
+      ...(cspPolicy
+        ? [
+            new CspHtmlWebpackPlugin(cspPolicy, cspOptions),
+            new NoncePlaceholder(),
+          ]
+        : []),
       // @dagster-io END
 
       // Inlines the webpack runtime script. This script is too small to warrant

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/react-scripts",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Dagster customization of configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -273,6 +273,11 @@ module.exports = {
   proxyOrigin: '',
 
   /**
+   * CSP nonce placeholder.
+   */
+  noncePlaceholder: '',
+
+  /**
    * Modules that must be deduped for the Webpack build, e.g. \`react\`. Ex:
    *
    * {


### PR DESCRIPTION
I'm changing our CSP to use the `strict-dymanic`-based approach recommended by Google: https://csp.withgoogle.com/docs/strict-csp.html

This will allow us to use third-party scripts in Cloud code more easily for Segment, which loads lots of code based on our specified destinations. The other option would be to list out every single relevant domain, which is getting out of hand.

The problem with this is that Webpack does not currently apply the CSP nonce to the built script tags, and without a `'self'`  on the `script-src` directive (which is ignored when `'strict-dynamic'` is used) the app simply fails to load anything due to the resulting CSP violation.

I'm using the workaround described here, including the snippet provided: https://towardsdatascience.com/content-security-policy-how-to-create-an-iron-clad-nonce-based-csp3-policy-with-webpack-and-nginx-ce5a4605db90. In our webpack config, we will insert the nonce placeholder (now added as a specification in `.dagster.js`) on the attributes of the generated nodes. This allows these scripts to run without running afoul of the CSP. Then, since `'script-dynamic'` is in use, other scripts can be loaded from that point.

Also:

- I ran `prettier` on the webpack config.
- I added `noncePlaceholder` to the `.dagster.js` template.